### PR TITLE
Dreamcast: Build recipe for lr-flycast on Pi 4 64-bit.

### DIFF
--- a/scriptmodules/libretrocores/lr-flycast.sh
+++ b/scriptmodules/libretrocores/lr-flycast.sh
@@ -39,7 +39,11 @@ function build_lr-flycast() {
     make clean
     if isPlatform "rpi"; then
         if isPlatform "rpi4"; then
-            params+=("platform=rpi4")
+            if isPlatform "aarch64"; then
+                params+=("ARCH=arm" "platform=rpi4_64")
+            else
+                params+=("platform=rpi4")
+            fi
         elif isPlatform "mesa"; then
             params+=("platform=rpi-mesa")
         else


### PR DESCRIPTION
for `ARCH=arm` see https://github.com/libretro/flycast/issues/853