### PR TITLE
Add armv8 to rpi4 64-bit platform flags.

### DIFF
--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -420,7 +420,7 @@ function platform_rpi4() {
         __platform_flags+=(arm armv8 neon)
     else
         __default_cpu_flags="-march=native"
-        __platform_flags+=(aarch64)
+        __platform_flags+=(aarch64 armv8)
     fi
     __platform_flags+=(rpi gles gles3)
 }


### PR DESCRIPTION
This is useful as adds lr-snes9x to main emulators, and also this: https://github.com/RetroPie/RetroPie-Setup/blob/6a663e1f7c0533f2321ff412fe860fdd9bbea2a4/scriptmodules/emulators/mupen64plus.sh#L112

For the other current uses of this flag in RetroPie, they are ignored as those emulators aren't available for rpi4 anyway.